### PR TITLE
fix: remove the addition of body class

### DIFF
--- a/src/bridge/index.js
+++ b/src/bridge/index.js
@@ -21,7 +21,6 @@ const applyStyles = () => {
     document.createTextNode('.fp-bridget__webview-hidden {display:none;}')
   )
   document.head.append(style)
-  document.body.classList.add('fp-bridget__webview-body')
 }
 
 const getElementContentByPropSelector = ({


### PR DESCRIPTION
According to the bridget documentation, the installation is done in the head-tag, when the body-tag is not available, hence we have an error.

I'm reverting the change and will cut a new release.

In case an integrator needs the functionality, my suggestion is for now to execute the following at the start of the body tag:
```html
<body>
    <script>
      if (this.bridget && this.bridget.isWebview()) {
        document.body.classList.add('fp-bridget__webview-body')
      }
    </script>
```