### PR TITLE
refactor: improve document metadata handling and usage of default values

### DIFF
--- a/src/bridge/util.js
+++ b/src/bridge/util.js
@@ -1,0 +1,38 @@
+const getElementContentByPropSelector = ({
+  element,
+  prop,
+  value,
+  innerHtml = false,
+  attribute = 'content',
+}) => {
+  // Content is sometimes inside the tag as an attribute, or between the tag as inner content
+  return innerHtml
+    ? document.querySelector(`${element}[${prop}^='${value}']`)?.innerHTML
+    : document
+        .querySelector(`${element}[${prop}^='${value}']`)
+        ?.getAttribute(attribute)
+}
+
+const getAllElementsByPropSelector = ({ element, prop, value }) => {
+  return document.querySelectorAll(`${element}[${prop}^='${value}']`) || []
+}
+
+const isInternalLink = (url, host) => {
+  return url.host === host
+}
+
+const isSharingLink = (element) => {
+  return element.classList.contains('fp-bridget__webview-social')
+}
+
+const filterObjectFromNullValues = (obj) => {
+  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v))
+}
+
+export {
+  getElementContentByPropSelector,
+  getAllElementsByPropSelector,
+  filterObjectFromNullValues,
+  isInternalLink,
+  isSharingLink
+}


### PR DESCRIPTION
This PR focuses on improving the handling of document metadata within `bridget`. Rather than using the `LDJSON` or `OpenGraph` metadata as they are and returning them raw, we keep in mind our default values as well (in addition to combining the metadata present on the web page in case certain properties are not present).

I realize it's far from perfect and should be further improved, but this will do for now. 